### PR TITLE
Support for localstack EDGE-Port

### DIFF
--- a/localstack-spring-boot-autoconfigure/pom.xml
+++ b/localstack-spring-boot-autoconfigure/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>io.smartup.localstack</groupId>
         <artifactId>localstack-spring-boot-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
         <relativePath>../localstack-spring-boot-parent</relativePath>
     </parent>
 
     <artifactId>localstack-spring-boot-autoconfigure</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>localstack-spring-boot-autoconfigure</name>
@@ -154,6 +154,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <scope>compile</scope>
+            <version>1.3.2</version>
         </dependency>
     </dependencies>
 

--- a/localstack-spring-boot-autoconfigure/pom.xml
+++ b/localstack-spring-boot-autoconfigure/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <scope>compile</scope>
+            <scope>provided</scope>
             <version>1.3.2</version>
         </dependency>
     </dependencies>

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AbstractAmazonClientConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AbstractAmazonClientConfigurator.java
@@ -15,6 +15,9 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 public abstract class AbstractAmazonClientConfigurator<T> implements ApplicationContextAware, BeanPostProcessor {
+
+    public static final int EDGE_PORT = 4566;
+
     private ApplicationContext applicationContext;
     protected boolean immutable;
 
@@ -40,10 +43,10 @@ public abstract class AbstractAmazonClientConfigurator<T> implements Application
         this.applicationContext = applicationContext;
     }
 
-    protected final String getLocalStackHost(int port) {
+    protected final String getLocalStackHost() {
         String protocol = useSsl ? "https://" : "http://";
 
-        return protocol + localStackHostProvider.provideLocalStackHost() + ":" + port;
+        return protocol + localStackHostProvider.provideLocalStackHost() + ":" + EDGE_PORT;
     }
 
     protected T getBean() {

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonDynamoDbConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonDynamoDbConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonDynamoDbConfigurator extends AbstractAmazonClientConfigurator
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4569);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonDynamoDbStreamsConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonDynamoDbStreamsConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonDynamoDbStreamsConfigurator extends AbstractAmazonClientConfi
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4569);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonKinesisConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonKinesisConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonKinesisConfigurator extends AbstractAmazonClientConfigurator<
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4568);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonLambdaConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonLambdaConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonLambdaConfigurator extends AbstractAmazonClientConfigurator<A
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4574);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonRoute53Configurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonRoute53Configurator.java
@@ -12,7 +12,7 @@ public class AmazonRoute53Configurator extends AbstractAmazonClientConfigurator<
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4580);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonS3Configurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonS3Configurator.java
@@ -13,7 +13,7 @@ public class AmazonS3Configurator extends AbstractAmazonClientConfigurator<Amazo
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4572);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSESConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSESConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonSESConfigurator extends AbstractAmazonClientConfigurator<Amaz
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4579);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSNSConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSNSConfigurator.java
@@ -12,7 +12,7 @@ public class AmazonSNSConfigurator extends AbstractAmazonClientConfigurator<Amaz
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4575);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSQSConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSQSConfigurator.java
@@ -16,7 +16,7 @@ public class AmazonSQSConfigurator extends AbstractAmazonClientConfigurator<Amaz
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4576);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSSMConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/AmazonSSMConfigurator.java
@@ -13,7 +13,7 @@ public class AmazonSSMConfigurator extends AbstractAmazonClientConfigurator<AWSS
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4583);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/SQSConnectionFactoryConfigurator.java
+++ b/localstack-spring-boot-autoconfigure/src/main/java/io/smartup/localstack/configurator/SQSConnectionFactoryConfigurator.java
@@ -12,7 +12,7 @@ public class SQSConnectionFactoryConfigurator extends AbstractAmazonClientConfig
 
     @Override
     public String getEndpoint() {
-        return getLocalStackHost(4576);
+        return getLocalStackHost();
     }
 
     @Override

--- a/localstack-spring-boot-parent/pom.xml
+++ b/localstack-spring-boot-parent/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.smartup.localstack</groupId>
     <artifactId>localstack-spring-boot-parent</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Boot Parent LocalStack</name>

--- a/localstack-spring-boot-starter/pom.xml
+++ b/localstack-spring-boot-starter/pom.xml
@@ -8,12 +8,12 @@
     <parent>
         <groupId>io.smartup.localstack</groupId>
         <artifactId>localstack-spring-boot-parent</artifactId>
-        <version>1.1.1</version>
+        <version>1.1.2-SNAPSHOT</version>
         <relativePath>../localstack-spring-boot-parent</relativePath>
     </parent>
 
     <artifactId>localstack-spring-boot-starter</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>localstack-spring-boot-starter</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.smartup.localstack</groupId>
     <artifactId>localstack-spring-boot-reactor</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>localstack-spring-boot-reactor</name>
     <description>LocalStack Spring Boot Reactor</description>


### PR DESCRIPTION
see announcement from 2020-11-15: A major (breaking) change has been merged in PR #2905 - starting with releases after v0.11.5, all services are now exposed via the edge service (port 4566) only!

Please merge this PR and publish version 1.1.2

I tested it with a SQS-Queue